### PR TITLE
Automate MSVC builds, and setup running CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ Release
 /xmplay/Debug
 /xmplay/Release
 /xmplay/*.dll
+/dependencies
+
+/**/test.zip
+/**/foo_input_vgmstream.fb2k-component

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,11 @@
+version: 1.0.{build}
+image: Visual Studio 2017
+configuration: Release
+build_script:
+- ps: .\build.bat
+test: off
+artifacts:
+- path: Release/test.zip
+  name: test.zip
+- path: Release/foo_input_vgmstream.fb2k-component
+  name: foo_input_vgmstream.fb2k-component

--- a/build.bat
+++ b/build.bat
@@ -1,0 +1,1 @@
+powershell -ExecutionPolicy Bypass -NoProfile -File .\build.ps1 Build

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,130 @@
+[CmdletBinding()]
+Param(
+    [Parameter(Position=0, mandatory=$true)]
+    [ValidateSet("Init", "Build", "Package")]
+    [string]$Task
+)
+
+$solution = "vgmstream_full.sln"
+$vswhere = "dependencies/vswhere.exe"
+$config = "/p:Configuration=Release"
+$onAppveyor = ($env:APPVEYOR -eq "true")
+$appveyorLoggerPath = "C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+
+$fb2kFiles = @(
+    "ext_libs/*.dll",
+    "ext_libs/*.dll.asc",
+    "Release/foo_input_vgmstream.dll",
+    "README.md"
+)
+
+$cliFiles = @(
+    "ext_libs/*.dll",
+    "Release/in_vgmstream.dll",
+    "Release/test.exe",
+    "Release/xmp-vgmstream.dll",
+    "COPYING",
+    "README.md"
+)
+
+function Unzip
+{
+    param([string]$zipfile, [string]$outpath)
+    Write-Output "Extracting $zipfile"
+    [System.IO.Compression.ZipFile]::ExtractToDirectory($zipfile, $outpath)
+}
+
+function Download
+{
+    param([string]$uri, [string]$outfile)
+    Write-Output "Downloading $uri"
+    $wc = New-Object net.webclient
+    $wc.Downloadfile($uri, $outfile)
+}
+
+function Init
+{
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+
+    Remove-Item -Path "dependencies" -Recurse -ErrorAction Ignore
+    New-Item dependencies -Type directory -Force | out-null
+
+    Download "https://github.com/kode54/fdk-aac/archive/master.zip" "dependencies\fdk-aac.zip"
+    Download "https://github.com/kode54/qaac/archive/master.zip" "dependencies\qaac.zip"
+    Download "https://www.nuget.org/api/v2/package/wtl/9.1.1" "dependencies\wtl.zip"
+    Download "https://github.com/Microsoft/vswhere/releases/download/2.2.11/vswhere.exe" "dependencies\vswhere.exe"
+
+    Download "https://www.foobar2000.org/SDK" "dependencies\SDK"
+    $key = (Select-String -Path dependencies\SDK -Pattern "\/([a-f0-9]+)\/SDK-2018-01-11\.zip").matches.groups[1]
+    Remove-Item -Path "dependencies\SDK"
+    Download "https://www.foobar2000.org/files/$key/SDK-2018-01-11.zip" "dependencies\foobar.zip"
+
+    Unzip "dependencies\fdk-aac.zip" "dependencies\fdk-aac_tmp"
+    Unzip "dependencies\qaac.zip" "dependencies\qaac_tmp"
+    Unzip "dependencies\wtl.zip" "dependencies\wtl_tmp"
+    Unzip "dependencies\foobar.zip" "dependencies\foobar"
+
+    Move-Item "dependencies\fdk-aac_tmp\fdk-aac-master" "dependencies\fdk-aac"
+    Move-Item "dependencies\qaac_tmp\qaac-master" "dependencies\qaac"
+    Move-Item "dependencies\wtl_tmp\lib\native" "dependencies\wtl"
+
+    Remove-Item -Path "dependencies\fdk-aac_tmp" -Recurse
+    Remove-Item -Path "dependencies\qaac_tmp" -Recurse
+    Remove-Item -Path "dependencies\wtl_tmp" -Recurse
+
+    [xml]$proj = Get-Content dependencies\foobar\foobar2000\ATLHelpers\foobar2000_ATL_helpers.vcxproj
+    $proj.project.ItemDefinitionGroup | ForEach-Object {
+        $includes = $proj.CreateElement("AdditionalIncludeDirectories", $proj.project.NamespaceURI)
+        $includes.InnerText = "../../../wtl/include"
+        $_.ClCompile.AppendChild($includes)
+    }
+    $proj.Save("dependencies\foobar\foobar2000\ATLHelpers\foobar2000_ATL_helpers.vcxproj")
+}
+
+function Package
+{
+    Compress-Archive $cliFiles Release/test.zip -Force
+    Compress-Archive $fb2kFiles Release/foo_input_vgmstream.zip -Force
+    Move-Item Release/foo_input_vgmstream.zip Release/foo_input_vgmstream.fb2k-component -Force
+}
+
+function Build
+{
+    $commit = & git describe --always --tag
+    if($onAppveyor) {
+        if($env:APPVEYOR_PULL_REQUEST_NUMBER) {
+            $prCommits = & git rev-list "$env:APPVEYOR_REPO_BRANCH.." --count
+            $prNum = ".PR$env:APPVEYOR_PULL_REQUEST_NUMBER.$prCommits"
+        }
+        if($env:APPVEYOR_REPO_BRANCH -ne "master") { $branch = ".$env:APPVEYOR_REPO_BRANCH" }
+        $version = "$commit$prNum$branch"
+        Update-AppveyorBuild -Version $version
+    }
+
+    if(!(Test-Path $vswhere)) { Init }
+
+    $msbuild = & $vswhere -latest -products * -requires Microsoft.Component.MSBuild -property installationPath
+    if ($msbuild) {
+      $msbuild = Join-Path $msbuild 'MSBuild\15.0\Bin\MSBuild.exe'
+    }
+
+    if(!($msbuild -and $(Test-Path $msbuild))) {
+        Write-Error "Unable to find MSBuild. Is Visual Studio installed?"
+    }
+
+    $logger = ""
+    if(Test-Path $appveyorLoggerPath) {
+        $logger = "/logger:$appveyorLoggerPath"
+    }
+
+    & $msbuild $solution $config $logger /m
+
+    Package
+}
+
+switch ($Task)
+{
+    "Init" { Init }
+    "Build" { Build }
+    "Package" { Package }
+}

--- a/fb2k/foo_input_vgmstream.vcxproj
+++ b/fb2k/foo_input_vgmstream.vcxproj
@@ -41,7 +41,7 @@
     <PlatformToolset>v141_xp</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Template|Win32'">
-    <PlatformToolset>v100</PlatformToolset>
+    <PlatformToolset>v141_xp</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -68,7 +68,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>../ext_includes;..\..\foobar\foobar2000\SDK;..\..\foobar\foobar2000\helpers;..\..\foobar\foobar2000\ATLHelpers;..\..\foobar\foobar2000\shared;../../qaac/mp4v2/include;../../fdk-aac/libSYS/include;../../fdk-aac/libAACdec/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\dependencies\wtl\include;../ext_includes;..\dependencies\foobar\foobar2000\SDK;..\dependencies\foobar\foobar2000\shared;..\dependencies\foobar\foobar2000;../dependencies/qaac/mp4v2/include;../dependencies/fdk-aac/libSYS/include;../dependencies/fdk-aac/libAACdec/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;VGM_USE_FFMPEG;VGM_USE_G7221;VGM_USE_MP4V2;VGM_USE_FDKAAC;VGM_USE_MAIATRAC3PLUS;_DEBUG;_WINDOWS;_USRDLL;IN_VGMSTREAM_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
@@ -81,8 +81,8 @@
       <AdditionalOptions>/d2notypeopt %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>../../foobar/foobar2000/shared/shared.lib;../ext_libs/libvorbis.lib;../ext_libs/libmpg123-0.lib;../ext_libs/libg7221_decode.lib;../ext_libs/libg719_decode.lib;../ext_libs/at3plusdecoder.lib;../ext_libs/avcodec.lib;../ext_libs/avformat.lib;../ext_libs/avutil.lib;../ext_libs/swresample.lib;../ext_libs/libatrac9.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>../dependencies/foobar/foobar2000/shared/shared.lib;../ext_libs/libvorbis.lib;../ext_libs/libmpg123-0.lib;../ext_libs/libg7221_decode.lib;../ext_libs/libg719_decode.lib;../ext_libs/at3plusdecoder.lib;../ext_libs/avcodec.lib;../ext_libs/avformat.lib;../ext_libs/avutil.lib;../ext_libs/swresample.lib;../ext_libs/libatrac9.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>../dependencies/foobar/foobar2000/shared/shared.lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <DelayLoadDLLs>%(DelayLoadDLLs)</DelayLoadDLLs>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
@@ -95,7 +95,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <AdditionalIncludeDirectories>../ext_includes;..\..\foobar\foobar2000\SDK;..\..\foobar\foobar2000\shared;..\..\foobar\foobar2000;../../qaac/mp4v2/include;../../fdk-aac/libSYS/include;../../fdk-aac/libAACdec/include;../../WTL/Include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\dependencies\wtl\include;../ext_includes;..\dependencies\foobar\foobar2000\SDK;..\dependencies\foobar\foobar2000\shared;..\dependencies\foobar\foobar2000;../dependencies/qaac/mp4v2/include;../dependencies/fdk-aac/libSYS/include;../dependencies/fdk-aac/libAACdec/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;VGM_USE_FFMPEG;VGM_USE_G7221;VGM_USE_MP4V2;VGM_USE_FDKAAC;VGM_USE_MAIATRAC3PLUS;NDEBUG;_WINDOWS;_USRDLL;IN_VGMSTREAM_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <PrecompiledHeader>
@@ -107,8 +107,8 @@
       <AdditionalOptions>/d2notypeopt</AdditionalOptions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>../../foobar/foobar2000/shared/shared.lib;../ext_libs/libvorbis.lib;../ext_libs/libmpg123-0.lib;../ext_libs/libg7221_decode.lib;../ext_libs/libg719_decode.lib;../ext_libs/at3plusdecoder.lib;../ext_libs/avcodec.lib;../ext_libs/avformat.lib;../ext_libs/avutil.lib;../ext_libs/swresample.lib;../ext_libs/libatrac9.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>../dependencies/foobar/foobar2000/shared/shared.lib;../ext_libs/libvorbis.lib;../ext_libs/libmpg123-0.lib;../ext_libs/libg7221_decode.lib;../ext_libs/libg719_decode.lib;../ext_libs/at3plusdecoder.lib;../ext_libs/avcodec.lib;../ext_libs/avformat.lib;../ext_libs/avutil.lib;../ext_libs/swresample.lib;../ext_libs/libatrac9.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>../dependencies/foobar/foobar2000/shared/shared.lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <IgnoreSpecificDefaultLibraries>%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
       <DelayLoadDLLs>%(DelayLoadDLLs)</DelayLoadDLLs>
       <OptimizeReferences>true</OptimizeReferences>
@@ -137,25 +137,25 @@
     <ClCompile Include="foo_vgmstream.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\fdk-aac\msvc\fdk-aac.vcxproj">
+    <ProjectReference Include="..\dependencies\fdk-aac\msvc\fdk-aac.vcxproj">
       <Project>{308e2ad5-be31-4770-9441-a8d50f56895c}</Project>
     </ProjectReference>
-    <ProjectReference Include="..\..\foobar\foobar2000\ATLHelpers\foobar2000_ATL_helpers.vcxproj">
+    <ProjectReference Include="..\dependencies\foobar\foobar2000\ATLHelpers\foobar2000_ATL_helpers.vcxproj">
       <Project>{622e8b19-8109-4717-bd4d-9657aa78363e}</Project>
     </ProjectReference>
-    <ProjectReference Include="..\..\foobar\foobar2000\foobar2000_component_client\foobar2000_component_client.vcxproj">
+    <ProjectReference Include="..\dependencies\foobar\foobar2000\foobar2000_component_client\foobar2000_component_client.vcxproj">
       <Project>{71ad2674-065b-48f5-b8b0-e1f9d3892081}</Project>
     </ProjectReference>
-    <ProjectReference Include="..\..\foobar\foobar2000\helpers\foobar2000_sdk_helpers.vcxproj">
+    <ProjectReference Include="..\dependencies\foobar\foobar2000\helpers\foobar2000_sdk_helpers.vcxproj">
       <Project>{ee47764e-a202-4f85-a767-abdab4aff35f}</Project>
     </ProjectReference>
-    <ProjectReference Include="..\..\foobar\foobar2000\SDK\foobar2000_SDK.vcxproj">
+    <ProjectReference Include="..\dependencies\foobar\foobar2000\SDK\foobar2000_SDK.vcxproj">
       <Project>{e8091321-d79d-4575-86ef-064ea1a4a20d}</Project>
     </ProjectReference>
-    <ProjectReference Include="..\..\foobar\pfc\pfc.vcxproj">
+    <ProjectReference Include="..\dependencies\foobar\pfc\pfc.vcxproj">
       <Project>{ebfffb4e-261d-44d3-b89c-957b31a0bf9c}</Project>
     </ProjectReference>
-    <ProjectReference Include="..\..\qaac\vcproject\mp4v2\mp4v2.vcxproj">
+    <ProjectReference Include="..\dependencies\qaac\vcproject\mp4v2\mp4v2.vcxproj">
       <Project>{86a064e2-c81b-4eee-8be0-a39a2e7c7c76}</Project>
     </ProjectReference>
     <ProjectReference Include="..\ext_libs\ext_libs.vcxproj">

--- a/init-build.bat
+++ b/init-build.bat
@@ -1,0 +1,1 @@
+powershell -ExecutionPolicy Bypass -NoProfile -File .\build.ps1 Init

--- a/package.bat
+++ b/package.bat
@@ -1,0 +1,1 @@
+powershell -ExecutionPolicy Bypass -NoProfile -File .\build.ps1 Package

--- a/src/libvgmstream.vcxproj
+++ b/src/libvgmstream.vcxproj
@@ -56,7 +56,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>../ext_includes;../../qaac/mp4v2/include;../../fdk-aac/libSYS/include;../../fdk-aac/libAACdec/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>../ext_includes;../dependencies/qaac/mp4v2/include;../dependencies/fdk-aac/libSYS/include;../dependencies/fdk-aac/libAACdec/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;VGM_USE_FFMPEG;VGM_USE_G7221;VGM_USE_G719;VGM_USE_MP4V2;VGM_USE_FDKAAC;VGM_USE_MAIATRAC3PLUS;VGM_USE_ATRAC9;USE_ALLOCA;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
@@ -70,7 +70,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <AdditionalIncludeDirectories>../ext_includes;../../qaac/mp4v2/include;../../fdk-aac/libSYS/include;../../fdk-aac/libAACdec/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>../ext_includes;../dependencies/qaac/mp4v2/include;../dependencies/fdk-aac/libSYS/include;../dependencies/fdk-aac/libAACdec/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_WIN32_WINNT=0x501;WIN32;VGM_USE_FFMPEG;VGM_USE_G7221;VGM_USE_G719;VGM_USE_MP4V2;VGM_USE_FDKAAC;VGM_USE_MAIATRAC3PLUS;VGM_USE_ATRAC9;USE_ALLOCA;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <PrecompiledHeader>

--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -68,7 +68,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>../ext_libs/Getopt;../ext_includes;../../qaac/mp4v2/include;../../fdk-aac/libSYS/include;../../fdk-aac/libAACdec/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>../ext_libs/Getopt;../ext_includes;../dependencies/qaac/mp4v2/include;../dependencies/fdk-aac/libSYS/include;../dependencies/fdk-aac/libAACdec/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;VGM_USE_FFMPEG;VGM_USE_G7221;VGM_USE_MP4V2;VGM_USE_FDKAAC;VGM_USE_MAIATRAC3PLUS;_DEBUG;_WINDOWS;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
@@ -94,7 +94,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <AdditionalIncludeDirectories>../ext_libs/Getopt;../ext_includes;../../qaac/mp4v2/include;../../fdk-aac/libSYS/include;../../fdk-aac/libAACdec/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>../ext_libs/Getopt;../ext_includes;../dependencies/qaac/mp4v2/include;../dependencies/fdk-aac/libSYS/include;../dependencies/fdk-aac/libAACdec/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;VGM_USE_FFMPEG;VGM_USE_G7221;VGM_USE_MP4V2;VGM_USE_FDKAAC;VGM_USE_MAIATRAC3PLUS;NDEBUG;_WINDOWS;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <PrecompiledHeader>
@@ -124,10 +124,10 @@
     <ClCompile Include="test.c" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\fdk-aac\msvc\fdk-aac.vcxproj">
+    <ProjectReference Include="..\dependencies\fdk-aac\msvc\fdk-aac.vcxproj">
       <Project>{308e2ad5-be31-4770-9441-a8d50f56895c}</Project>
     </ProjectReference>
-    <ProjectReference Include="..\..\qaac\vcproject\mp4v2\mp4v2.vcxproj">
+    <ProjectReference Include="..\dependencies\qaac\vcproject\mp4v2\mp4v2.vcxproj">
       <Project>{86a064e2-c81b-4eee-8be0-a39a2e7c7c76}</Project>
     </ProjectReference>
     <ProjectReference Include="..\ext_libs\ext_libs.vcxproj">

--- a/vgmstream_full.sln
+++ b/vgmstream_full.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.27130.2020
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libvgmstream", "src\libvgmstream.vcxproj", "{54A6AD11-5369-4895-A06F-E255ABB99B11}"
 EndProject
@@ -9,9 +9,9 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ext_libs", "ext_libs\ext_li
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "getopt", "ext_libs\Getopt\getopt.vcxproj", "{330B53AE-4FAE-46DA-8785-9016DB4E3E23}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "fdk-aac", "..\fdk-aac\msvc\fdk-aac.vcxproj", "{308E2AD5-BE31-4770-9441-A8D50F56895C}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "fdk-aac", "dependencies\fdk-aac\msvc\fdk-aac.vcxproj", "{308E2AD5-BE31-4770-9441-A8D50F56895C}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "mp4v2", "..\qaac\vcproject\mp4v2\mp4v2.vcxproj", "{86A064E2-C81B-4EEE-8BE0-A39A2E7C7C76}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "mp4v2", "dependencies\qaac\vcproject\mp4v2\mp4v2.vcxproj", "{86A064E2-C81B-4EEE-8BE0-A39A2E7C7C76}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "test", "test\test.vcxproj", "{AF7D88A0-3CB1-4CD8-BAD1-0305EB996D69}"
 EndProject
@@ -19,15 +19,15 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "in_vgmstream", "winamp\in_v
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "foo_input_vgmstream", "fb2k\foo_input_vgmstream.vcxproj", "{F3739CF2-F422-4A3D-BB0A-53C5D4C5ABA0}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "foobar2000_SDK", "..\foobar\foobar2000\SDK\foobar2000_SDK.vcxproj", "{E8091321-D79D-4575-86EF-064EA1A4A20D}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "foobar2000_SDK", "dependencies\foobar\foobar2000\SDK\foobar2000_SDK.vcxproj", "{E8091321-D79D-4575-86EF-064EA1A4A20D}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "foobar2000_sdk_helpers", "..\foobar\foobar2000\helpers\foobar2000_sdk_helpers.vcxproj", "{EE47764E-A202-4F85-A767-ABDAB4AFF35F}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "foobar2000_sdk_helpers", "dependencies\foobar\foobar2000\helpers\foobar2000_sdk_helpers.vcxproj", "{EE47764E-A202-4F85-A767-ABDAB4AFF35F}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "foobar2000_ATL_helpers", "..\foobar\foobar2000\ATLHelpers\foobar2000_ATL_helpers.vcxproj", "{622E8B19-8109-4717-BD4D-9657AA78363E}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "foobar2000_ATL_helpers", "dependencies\foobar\foobar2000\ATLHelpers\foobar2000_ATL_helpers.vcxproj", "{622E8B19-8109-4717-BD4D-9657AA78363E}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "foobar2000_component_client", "..\foobar\foobar2000\foobar2000_component_client\foobar2000_component_client.vcxproj", "{71AD2674-065B-48F5-B8B0-E1F9D3892081}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "foobar2000_component_client", "dependencies\foobar\foobar2000\foobar2000_component_client\foobar2000_component_client.vcxproj", "{71AD2674-065B-48F5-B8B0-E1F9D3892081}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "pfc", "..\foobar\pfc\pfc.vcxproj", "{EBFFFB4E-261D-44D3-B89C-957B31A0BF9C}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "pfc", "dependencies\foobar\pfc\pfc.vcxproj", "{EBFFFB4E-261D-44D3-B89C-957B31A0BF9C}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "xmp-vgmstream", "xmplay\xmp-vgmstream.vcxproj", "{49AF76F7-CBA0-4486-9DDF-51F30DF45F33}"
 EndProject
@@ -71,6 +71,46 @@ Global
 		{330B53AE-4FAE-46DA-8785-9016DB4E3E23}.Template|Win32.Build.0 = Release|Win32
 		{330B53AE-4FAE-46DA-8785-9016DB4E3E23}.Template|x64.ActiveCfg = Release|Win32
 		{330B53AE-4FAE-46DA-8785-9016DB4E3E23}.Template|x64.Build.0 = Release|Win32
+		{308E2AD5-BE31-4770-9441-A8D50F56895C}.Debug|Win32.ActiveCfg = Debug|Win32
+		{308E2AD5-BE31-4770-9441-A8D50F56895C}.Debug|Win32.Build.0 = Debug|Win32
+		{308E2AD5-BE31-4770-9441-A8D50F56895C}.Debug|x64.ActiveCfg = Debug|Win32
+		{308E2AD5-BE31-4770-9441-A8D50F56895C}.Release|Win32.ActiveCfg = Release|Win32
+		{308E2AD5-BE31-4770-9441-A8D50F56895C}.Release|Win32.Build.0 = Release|Win32
+		{308E2AD5-BE31-4770-9441-A8D50F56895C}.Release|x64.ActiveCfg = Release|Win32
+		{308E2AD5-BE31-4770-9441-A8D50F56895C}.Template|Win32.ActiveCfg = Release|Win32
+		{308E2AD5-BE31-4770-9441-A8D50F56895C}.Template|Win32.Build.0 = Release|Win32
+		{308E2AD5-BE31-4770-9441-A8D50F56895C}.Template|x64.ActiveCfg = Release|Win32
+		{308E2AD5-BE31-4770-9441-A8D50F56895C}.Template|x64.Build.0 = Release|Win32
+		{86A064E2-C81B-4EEE-8BE0-A39A2E7C7C76}.Debug|Win32.ActiveCfg = Debug|Win32
+		{86A064E2-C81B-4EEE-8BE0-A39A2E7C7C76}.Debug|Win32.Build.0 = Debug|Win32
+		{86A064E2-C81B-4EEE-8BE0-A39A2E7C7C76}.Debug|x64.ActiveCfg = Debug|x64
+		{86A064E2-C81B-4EEE-8BE0-A39A2E7C7C76}.Debug|x64.Build.0 = Debug|x64
+		{86A064E2-C81B-4EEE-8BE0-A39A2E7C7C76}.Release|Win32.ActiveCfg = Release|Win32
+		{86A064E2-C81B-4EEE-8BE0-A39A2E7C7C76}.Release|Win32.Build.0 = Release|Win32
+		{86A064E2-C81B-4EEE-8BE0-A39A2E7C7C76}.Release|x64.ActiveCfg = Release|x64
+		{86A064E2-C81B-4EEE-8BE0-A39A2E7C7C76}.Release|x64.Build.0 = Release|x64
+		{86A064E2-C81B-4EEE-8BE0-A39A2E7C7C76}.Template|Win32.ActiveCfg = Release|Win32
+		{86A064E2-C81B-4EEE-8BE0-A39A2E7C7C76}.Template|Win32.Build.0 = Release|Win32
+		{86A064E2-C81B-4EEE-8BE0-A39A2E7C7C76}.Template|x64.ActiveCfg = Release|x64
+		{86A064E2-C81B-4EEE-8BE0-A39A2E7C7C76}.Template|x64.Build.0 = Release|x64
+		{AF7D88A0-3CB1-4CD8-BAD1-0305EB996D69}.Debug|Win32.ActiveCfg = Debug|Win32
+		{AF7D88A0-3CB1-4CD8-BAD1-0305EB996D69}.Debug|Win32.Build.0 = Debug|Win32
+		{AF7D88A0-3CB1-4CD8-BAD1-0305EB996D69}.Debug|x64.ActiveCfg = Debug|Win32
+		{AF7D88A0-3CB1-4CD8-BAD1-0305EB996D69}.Release|Win32.ActiveCfg = Release|Win32
+		{AF7D88A0-3CB1-4CD8-BAD1-0305EB996D69}.Release|Win32.Build.0 = Release|Win32
+		{AF7D88A0-3CB1-4CD8-BAD1-0305EB996D69}.Release|x64.ActiveCfg = Release|Win32
+		{AF7D88A0-3CB1-4CD8-BAD1-0305EB996D69}.Template|Win32.ActiveCfg = Template|Win32
+		{AF7D88A0-3CB1-4CD8-BAD1-0305EB996D69}.Template|Win32.Build.0 = Template|Win32
+		{AF7D88A0-3CB1-4CD8-BAD1-0305EB996D69}.Template|x64.ActiveCfg = Template|Win32
+		{42D86561-8CE4-40F5-86CE-58C986B77502}.Debug|Win32.ActiveCfg = Debug|Win32
+		{42D86561-8CE4-40F5-86CE-58C986B77502}.Debug|Win32.Build.0 = Debug|Win32
+		{42D86561-8CE4-40F5-86CE-58C986B77502}.Debug|x64.ActiveCfg = Debug|Win32
+		{42D86561-8CE4-40F5-86CE-58C986B77502}.Release|Win32.ActiveCfg = Release|Win32
+		{42D86561-8CE4-40F5-86CE-58C986B77502}.Release|Win32.Build.0 = Release|Win32
+		{42D86561-8CE4-40F5-86CE-58C986B77502}.Release|x64.ActiveCfg = Release|Win32
+		{42D86561-8CE4-40F5-86CE-58C986B77502}.Template|Win32.ActiveCfg = Template|Win32
+		{42D86561-8CE4-40F5-86CE-58C986B77502}.Template|Win32.Build.0 = Template|Win32
+		{42D86561-8CE4-40F5-86CE-58C986B77502}.Template|x64.ActiveCfg = Template|Win32
 		{F3739CF2-F422-4A3D-BB0A-53C5D4C5ABA0}.Debug|Win32.ActiveCfg = Debug|Win32
 		{F3739CF2-F422-4A3D-BB0A-53C5D4C5ABA0}.Debug|Win32.Build.0 = Debug|Win32
 		{F3739CF2-F422-4A3D-BB0A-53C5D4C5ABA0}.Debug|x64.ActiveCfg = Debug|Win32
@@ -80,68 +120,75 @@ Global
 		{F3739CF2-F422-4A3D-BB0A-53C5D4C5ABA0}.Template|Win32.ActiveCfg = Template|Win32
 		{F3739CF2-F422-4A3D-BB0A-53C5D4C5ABA0}.Template|Win32.Build.0 = Template|Win32
 		{F3739CF2-F422-4A3D-BB0A-53C5D4C5ABA0}.Template|x64.ActiveCfg = Template|Win32
-		{EBFFFB4E-261D-44D3-B89C-957B31A0BF9C}.Debug|Win32.ActiveCfg = Debug|Win32
-		{EBFFFB4E-261D-44D3-B89C-957B31A0BF9C}.Debug|Win32.Build.0 = Debug|Win32
-		{EBFFFB4E-261D-44D3-B89C-957B31A0BF9C}.Debug|x64.ActiveCfg = Debug|x64
-		{EBFFFB4E-261D-44D3-B89C-957B31A0BF9C}.Debug|x64.Build.0 = Debug|x64
-		{EBFFFB4E-261D-44D3-B89C-957B31A0BF9C}.Release|Win32.ActiveCfg = Release|Win32
-		{EBFFFB4E-261D-44D3-B89C-957B31A0BF9C}.Release|Win32.Build.0 = Release|Win32
-		{EBFFFB4E-261D-44D3-B89C-957B31A0BF9C}.Release|x64.ActiveCfg = Release|x64
-		{EBFFFB4E-261D-44D3-B89C-957B31A0BF9C}.Release|x64.Build.0 = Release|x64
-		{EBFFFB4E-261D-44D3-B89C-957B31A0BF9C}.Template|Win32.ActiveCfg = Release|Win32
-		{EBFFFB4E-261D-44D3-B89C-957B31A0BF9C}.Template|Win32.Build.0 = Release|Win32
-		{EBFFFB4E-261D-44D3-B89C-957B31A0BF9C}.Template|x64.ActiveCfg = Release|x64
-		{EBFFFB4E-261D-44D3-B89C-957B31A0BF9C}.Template|x64.Build.0 = Release|x64
 		{E8091321-D79D-4575-86EF-064EA1A4A20D}.Debug|Win32.ActiveCfg = Debug|Win32
 		{E8091321-D79D-4575-86EF-064EA1A4A20D}.Debug|Win32.Build.0 = Debug|Win32
-		{E8091321-D79D-4575-86EF-064EA1A4A20D}.Debug|x64.ActiveCfg = Debug|x64
-		{E8091321-D79D-4575-86EF-064EA1A4A20D}.Debug|x64.Build.0 = Debug|x64
+		{E8091321-D79D-4575-86EF-064EA1A4A20D}.Debug|x64.ActiveCfg = Debug|Win32
 		{E8091321-D79D-4575-86EF-064EA1A4A20D}.Release|Win32.ActiveCfg = Release|Win32
 		{E8091321-D79D-4575-86EF-064EA1A4A20D}.Release|Win32.Build.0 = Release|Win32
-		{E8091321-D79D-4575-86EF-064EA1A4A20D}.Release|x64.ActiveCfg = Release|x64
-		{E8091321-D79D-4575-86EF-064EA1A4A20D}.Release|x64.Build.0 = Release|x64
+		{E8091321-D79D-4575-86EF-064EA1A4A20D}.Release|x64.ActiveCfg = Release|Win32
 		{E8091321-D79D-4575-86EF-064EA1A4A20D}.Template|Win32.ActiveCfg = Release|Win32
 		{E8091321-D79D-4575-86EF-064EA1A4A20D}.Template|Win32.Build.0 = Release|Win32
-		{E8091321-D79D-4575-86EF-064EA1A4A20D}.Template|x64.ActiveCfg = Release|x64
-		{E8091321-D79D-4575-86EF-064EA1A4A20D}.Template|x64.Build.0 = Release|x64
+		{E8091321-D79D-4575-86EF-064EA1A4A20D}.Template|x64.ActiveCfg = Release|Win32
+		{E8091321-D79D-4575-86EF-064EA1A4A20D}.Template|x64.Build.0 = Release|Win32
+		{E8091321-D79D-4575-86EF-064EA1A4A20D}.Template|x64.Deploy.0 = Release|Win32
 		{EE47764E-A202-4F85-A767-ABDAB4AFF35F}.Debug|Win32.ActiveCfg = Debug|Win32
 		{EE47764E-A202-4F85-A767-ABDAB4AFF35F}.Debug|Win32.Build.0 = Debug|Win32
-		{EE47764E-A202-4F85-A767-ABDAB4AFF35F}.Debug|x64.ActiveCfg = Debug|x64
-		{EE47764E-A202-4F85-A767-ABDAB4AFF35F}.Debug|x64.Build.0 = Debug|x64
+		{EE47764E-A202-4F85-A767-ABDAB4AFF35F}.Debug|x64.ActiveCfg = Debug|Win32
 		{EE47764E-A202-4F85-A767-ABDAB4AFF35F}.Release|Win32.ActiveCfg = Release|Win32
 		{EE47764E-A202-4F85-A767-ABDAB4AFF35F}.Release|Win32.Build.0 = Release|Win32
-		{EE47764E-A202-4F85-A767-ABDAB4AFF35F}.Release|x64.ActiveCfg = Release|x64
-		{EE47764E-A202-4F85-A767-ABDAB4AFF35F}.Release|x64.Build.0 = Release|x64
+		{EE47764E-A202-4F85-A767-ABDAB4AFF35F}.Release|x64.ActiveCfg = Release|Win32
 		{EE47764E-A202-4F85-A767-ABDAB4AFF35F}.Template|Win32.ActiveCfg = Release|Win32
 		{EE47764E-A202-4F85-A767-ABDAB4AFF35F}.Template|Win32.Build.0 = Release|Win32
-		{EE47764E-A202-4F85-A767-ABDAB4AFF35F}.Template|x64.ActiveCfg = Release|x64
-		{EE47764E-A202-4F85-A767-ABDAB4AFF35F}.Template|x64.Build.0 = Release|x64
+		{EE47764E-A202-4F85-A767-ABDAB4AFF35F}.Template|x64.ActiveCfg = Release|Win32
+		{EE47764E-A202-4F85-A767-ABDAB4AFF35F}.Template|x64.Build.0 = Release|Win32
+		{EE47764E-A202-4F85-A767-ABDAB4AFF35F}.Template|x64.Deploy.0 = Release|Win32
 		{622E8B19-8109-4717-BD4D-9657AA78363E}.Debug|Win32.ActiveCfg = Debug|Win32
 		{622E8B19-8109-4717-BD4D-9657AA78363E}.Debug|Win32.Build.0 = Debug|Win32
-		{622E8B19-8109-4717-BD4D-9657AA78363E}.Debug|x64.ActiveCfg = Debug|x64
-		{622E8B19-8109-4717-BD4D-9657AA78363E}.Debug|x64.Build.0 = Debug|x64
+		{622E8B19-8109-4717-BD4D-9657AA78363E}.Debug|x64.ActiveCfg = Debug|Win32
 		{622E8B19-8109-4717-BD4D-9657AA78363E}.Release|Win32.ActiveCfg = Release|Win32
 		{622E8B19-8109-4717-BD4D-9657AA78363E}.Release|Win32.Build.0 = Release|Win32
-		{622E8B19-8109-4717-BD4D-9657AA78363E}.Release|x64.ActiveCfg = Release|x64
-		{622E8B19-8109-4717-BD4D-9657AA78363E}.Release|x64.Build.0 = Release|x64
+		{622E8B19-8109-4717-BD4D-9657AA78363E}.Release|x64.ActiveCfg = Release|Win32
 		{622E8B19-8109-4717-BD4D-9657AA78363E}.Template|Win32.ActiveCfg = Release|Win32
 		{622E8B19-8109-4717-BD4D-9657AA78363E}.Template|Win32.Build.0 = Release|Win32
-		{622E8B19-8109-4717-BD4D-9657AA78363E}.Template|x64.ActiveCfg = Release|x64
-		{622E8B19-8109-4717-BD4D-9657AA78363E}.Template|x64.Build.0 = Release|x64
+		{622E8B19-8109-4717-BD4D-9657AA78363E}.Template|x64.ActiveCfg = Release|Win32
+		{622E8B19-8109-4717-BD4D-9657AA78363E}.Template|x64.Build.0 = Release|Win32
+		{622E8B19-8109-4717-BD4D-9657AA78363E}.Template|x64.Deploy.0 = Release|Win32
 		{71AD2674-065B-48F5-B8B0-E1F9D3892081}.Debug|Win32.ActiveCfg = Debug|Win32
 		{71AD2674-065B-48F5-B8B0-E1F9D3892081}.Debug|Win32.Build.0 = Debug|Win32
-		{71AD2674-065B-48F5-B8B0-E1F9D3892081}.Debug|x64.ActiveCfg = Debug|x64
-		{71AD2674-065B-48F5-B8B0-E1F9D3892081}.Debug|x64.Build.0 = Debug|x64
+		{71AD2674-065B-48F5-B8B0-E1F9D3892081}.Debug|x64.ActiveCfg = Debug|Win32
 		{71AD2674-065B-48F5-B8B0-E1F9D3892081}.Release|Win32.ActiveCfg = Release|Win32
 		{71AD2674-065B-48F5-B8B0-E1F9D3892081}.Release|Win32.Build.0 = Release|Win32
-		{71AD2674-065B-48F5-B8B0-E1F9D3892081}.Release|x64.ActiveCfg = Release|x64
-		{71AD2674-065B-48F5-B8B0-E1F9D3892081}.Release|x64.Build.0 = Release|x64
+		{71AD2674-065B-48F5-B8B0-E1F9D3892081}.Release|x64.ActiveCfg = Release|Win32
 		{71AD2674-065B-48F5-B8B0-E1F9D3892081}.Template|Win32.ActiveCfg = Release|Win32
 		{71AD2674-065B-48F5-B8B0-E1F9D3892081}.Template|Win32.Build.0 = Release|Win32
-		{71AD2674-065B-48F5-B8B0-E1F9D3892081}.Template|x64.ActiveCfg = Release|x64
-		{71AD2674-065B-48F5-B8B0-E1F9D3892081}.Template|x64.Build.0 = Release|x64
+		{71AD2674-065B-48F5-B8B0-E1F9D3892081}.Template|x64.ActiveCfg = Release|Win32
+		{71AD2674-065B-48F5-B8B0-E1F9D3892081}.Template|x64.Build.0 = Release|Win32
+		{71AD2674-065B-48F5-B8B0-E1F9D3892081}.Template|x64.Deploy.0 = Release|Win32
+		{EBFFFB4E-261D-44D3-B89C-957B31A0BF9C}.Debug|Win32.ActiveCfg = Debug|Win32
+		{EBFFFB4E-261D-44D3-B89C-957B31A0BF9C}.Debug|Win32.Build.0 = Debug|Win32
+		{EBFFFB4E-261D-44D3-B89C-957B31A0BF9C}.Debug|x64.ActiveCfg = Debug|Win32
+		{EBFFFB4E-261D-44D3-B89C-957B31A0BF9C}.Release|Win32.ActiveCfg = Release|Win32
+		{EBFFFB4E-261D-44D3-B89C-957B31A0BF9C}.Release|Win32.Build.0 = Release|Win32
+		{EBFFFB4E-261D-44D3-B89C-957B31A0BF9C}.Release|x64.ActiveCfg = Release|Win32
+		{EBFFFB4E-261D-44D3-B89C-957B31A0BF9C}.Template|Win32.ActiveCfg = Release|Win32
+		{EBFFFB4E-261D-44D3-B89C-957B31A0BF9C}.Template|Win32.Build.0 = Release|Win32
+		{EBFFFB4E-261D-44D3-B89C-957B31A0BF9C}.Template|x64.ActiveCfg = Release|Win32
+		{EBFFFB4E-261D-44D3-B89C-957B31A0BF9C}.Template|x64.Build.0 = Release|Win32
+		{EBFFFB4E-261D-44D3-B89C-957B31A0BF9C}.Template|x64.Deploy.0 = Release|Win32
+		{49AF76F7-CBA0-4486-9DDF-51F30DF45F33}.Debug|Win32.ActiveCfg = Debug|Win32
+		{49AF76F7-CBA0-4486-9DDF-51F30DF45F33}.Debug|Win32.Build.0 = Debug|Win32
+		{49AF76F7-CBA0-4486-9DDF-51F30DF45F33}.Debug|x64.ActiveCfg = Debug|Win32
+		{49AF76F7-CBA0-4486-9DDF-51F30DF45F33}.Release|Win32.ActiveCfg = Release|Win32
+		{49AF76F7-CBA0-4486-9DDF-51F30DF45F33}.Release|Win32.Build.0 = Release|Win32
+		{49AF76F7-CBA0-4486-9DDF-51F30DF45F33}.Release|x64.ActiveCfg = Release|Win32
+		{49AF76F7-CBA0-4486-9DDF-51F30DF45F33}.Template|Win32.ActiveCfg = Template|Win32
+		{49AF76F7-CBA0-4486-9DDF-51F30DF45F33}.Template|Win32.Build.0 = Template|Win32
+		{49AF76F7-CBA0-4486-9DDF-51F30DF45F33}.Template|x64.ActiveCfg = Template|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {31FD2BB7-AE1D-4803-8669-B881133780B0}
 	EndGlobalSection
 EndGlobal

--- a/winamp/in_vgmstream.vcxproj
+++ b/winamp/in_vgmstream.vcxproj
@@ -68,7 +68,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>../ext_includes;../../qaac/mp4v2/include;../../fdk-aac/libSYS/include;../../fdk-aac/libAACdec/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>../ext_includes;../dependencies/qaac/mp4v2/include;../dependencies/fdk-aac/libSYS/include;../dependencies/fdk-aac/libAACdec/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;VGM_USE_FFMPEG;VGM_USE_G7221;VGM_USE_MP4V2;VGM_USE_FDKAAC;VGM_USE_MAIATRAC3PLUS;_DEBUG;_WINDOWS;_USRDLL;IN_VGMSTREAM_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
@@ -96,7 +96,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <AdditionalIncludeDirectories>../ext_includes;../../qaac/mp4v2/include;../../fdk-aac/libSYS/include;../../fdk-aac/libAACdec/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>../ext_includes;../dependencies/qaac/mp4v2/include;../dependencies/fdk-aac/libSYS/include;../dependencies/fdk-aac/libAACdec/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;VGM_USE_FFMPEG;VGM_USE_G7221;VGM_USE_MP4V2;VGM_USE_FDKAAC;VGM_USE_MAIATRAC3PLUS;NDEBUG;_WINDOWS;_USRDLL;IN_VGMSTREAM_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <PrecompiledHeader>
@@ -134,10 +134,10 @@
     <ClCompile Include="in_vgmstream.c" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\fdk-aac\msvc\fdk-aac.vcxproj">
+    <ProjectReference Include="..\dependencies\fdk-aac\msvc\fdk-aac.vcxproj">
       <Project>{308e2ad5-be31-4770-9441-a8d50f56895c}</Project>
     </ProjectReference>
-    <ProjectReference Include="..\..\qaac\vcproject\mp4v2\mp4v2.vcxproj">
+    <ProjectReference Include="..\dependencies\qaac\vcproject\mp4v2\mp4v2.vcxproj">
       <Project>{86a064e2-c81b-4eee-8be0-a39a2e7c7c76}</Project>
     </ProjectReference>
     <ProjectReference Include="..\ext_libs\ext_libs.vcxproj">

--- a/xmplay/xmp-vgmstream.vcxproj
+++ b/xmplay/xmp-vgmstream.vcxproj
@@ -59,7 +59,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>../ext_includes;../../qaac/mp4v2/include;../../fdk-aac/libSYS/include;../../fdk-aac/libAACdec/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>../ext_includes;../dependencies/qaac/mp4v2/include;../dependencies/fdk-aac/libSYS/include;../dependencies/fdk-aac/libAACdec/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;VGM_USE_FFMPEG;VGM_USE_G7221;VGM_USE_MP4V2;VGM_USE_FDKAAC;VGM_USE_MAIATRAC3PLUS;_DEBUG;_WINDOWS;_USRDLL;IN_VGMSTREAM_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
@@ -84,7 +84,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <AdditionalIncludeDirectories>../ext_includes;../../qaac/mp4v2/include;../../fdk-aac/libSYS/include;../../fdk-aac/libAACdec/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>../ext_includes;../dependencies/qaac/mp4v2/include;../dependencies/fdk-aac/libSYS/include;../dependencies/fdk-aac/libAACdec/include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_WIN32_WINNT=0x501;WIN32;VGM_USE_FFMPEG;VGM_USE_G7221;VGM_USE_MP4V2;VGM_USE_FDKAAC;VGM_USE_MAIATRAC3PLUS;NDEBUG;_WINDOWS;_USRDLL;IN_VGMSTREAM_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
@@ -123,10 +123,10 @@
     <None Include="xmpin.def" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\fdk-aac\msvc\fdk-aac.vcxproj">
+    <ProjectReference Include="..\dependencies\fdk-aac\msvc\fdk-aac.vcxproj">
       <Project>{308e2ad5-be31-4770-9441-a8d50f56895c}</Project>
     </ProjectReference>
-    <ProjectReference Include="..\..\qaac\vcproject\mp4v2\mp4v2.vcxproj">
+    <ProjectReference Include="..\dependencies\qaac\vcproject\mp4v2\mp4v2.vcxproj">
       <Project>{86a064e2-c81b-4eee-8be0-a39a2e7c7c76}</Project>
     </ProjectReference>
     <ProjectReference Include="..\ext_libs\ext_libs.vcxproj">


### PR DESCRIPTION
- Add a script to download dependencies
- Move dependencies to "/dependencies"
- Update solution file so it contains all projects
- Add a script for building and packaging the MSVC builds
- Add information for using AppVeyor's continuous integration service

Changes to the projects themselves are minimal. I only needed to change the dependency paths, and update the solution configurations because it didn't include all the projects.

All that's needed to enable CI builds is adding the project to AppVeyor Names and version strings can be adjusted if necessary.